### PR TITLE
Feature/optional authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,6 @@
             <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>net.smartcosmos</groupId>
-            <artifactId>smartcosmos-framework-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
@@ -106,6 +101,11 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>1.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-framework-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
             <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/src/main/java/net/smartcosmos/extension/tenant/TenantRdao.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/TenantRdao.java
@@ -1,5 +1,10 @@
 package net.smartcosmos.extension.tenant;
 
+import net.smartcosmos.annotation.EnableSmartCosmosEvents;
+import net.smartcosmos.annotation.EnableSmartCosmosExtension;
+import net.smartcosmos.annotation.EnableSmartCosmosSecurity;
+import net.smartcosmos.extension.tenant.config.AnonymousAccessSecurityConfiguration;
+import net.smartcosmos.extension.tenant.config.ServiceUserAccessSecurityConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -9,17 +14,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-import net.smartcosmos.annotation.EnableSmartCosmosEvents;
-import net.smartcosmos.annotation.EnableSmartCosmosExtension;
-import net.smartcosmos.annotation.EnableSmartCosmosSecurity;
-import net.smartcosmos.extension.tenant.config.AnonymousAccessSecurityConfiguration;
-
 @EnableSmartCosmosExtension
 @EnableSmartCosmosEvents
 @EnableSmartCosmosSecurity
 @EnableWebMvc
-//@Import({ AnonymousAccessSecurityConfiguration.class, ServiceUserAccessSecurityConfiguration.class})
-@Import({ AnonymousAccessSecurityConfiguration.class})
+@Import({ AnonymousAccessSecurityConfiguration.class, ServiceUserAccessSecurityConfiguration.class})
 @ComponentScan
 public class TenantRdao extends WebMvcConfigurerAdapter {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosAnonymousUser.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosAnonymousUser.java
@@ -7,16 +7,35 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import java.util.ArrayList;
 import java.util.Collection;
 
+/**
+ * Constant interface for ANONYMOUS User configuration.
+ */
 public interface SmartCosmosAnonymousUser {
 
+    /**
+     * Internal key to identify if this object made by an authorised client,
+     * see documentation for {@link org.springframework.security.authentication.AnonymousAuthenticationToken}.
+     */
     String ANONYMOUS_AUTHENTICATION_KEY = "0e11c838-9b18-4796-98ad-f9dfa946aec1";
 
+    /**
+     * User name for the ANONYMOUS user.
+     */
     String ANONYMOUS_USER_NAME = "ANONYMOUS";
 
+    /**
+     * Name of the ANONYMOUS user's role, used for the default authority {@code "hasRole('" + ANONYMOUS_USER_ROLE + "')"}.
+     */
     String ANONYMOUS_USER_ROLE = "ROLE_ANONYMOUS";
 
+    /**
+     * The default authorities of the ANONYMOUS user.
+     */
     Collection<GrantedAuthority> ANONYMOUS_USER_AUTHORITIES = anonymousUserAuthorities();
 
+    /**
+     * An instance of {@link SmartCosmosUser} for the ANONYMOUS user.
+     */
     SmartCosmosUser ANONYMOUS_USER = new SmartCosmosUser(null, null, ANONYMOUS_USER_NAME, "", ANONYMOUS_USER_AUTHORITIES);
 
     static Collection<GrantedAuthority> anonymousUserAuthorities() {

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosAnonymousUser.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosAnonymousUser.java
@@ -1,0 +1,29 @@
+package net.smartcosmos.extension.tenant.auth;
+
+import net.smartcosmos.security.user.SmartCosmosUser;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public interface SmartCosmosAnonymousUser {
+
+    String ANONYMOUS_AUTHENTICATION_KEY = "0e11c838-9b18-4796-98ad-f9dfa946aec1";
+
+    String ANONYMOUS_USER_NAME = "ANONYMOUS";
+
+    String ANONYMOUS_USER_ROLE = "ROLE_ANONYMOUS";
+
+    Collection<GrantedAuthority> ANONYMOUS_USER_AUTHORITIES = anonymousUserAuthorities();
+
+    SmartCosmosUser ANONYMOUS_USER = new SmartCosmosUser(null, null, ANONYMOUS_USER_NAME, "", ANONYMOUS_USER_AUTHORITIES);
+
+    static Collection<GrantedAuthority> anonymousUserAuthorities() {
+
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("hasRole('" + ANONYMOUS_USER_ROLE + "')"));
+
+        return authorities;
+    }
+}

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosServiceUser.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosServiceUser.java
@@ -1,0 +1,38 @@
+package net.smartcosmos.extension.tenant.auth;
+
+import net.smartcosmos.security.user.SmartCosmosUser;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ *
+ */
+public interface SmartCosmosServiceUser {
+
+    String SERVICE_USER_ROLE = "ROLE_SMARTCOSMOS_SERVICE_CLIENT";
+
+    Collection<GrantedAuthority> DEFAULT_SERVICE_USER_AUTHORITIES = defaultServiceUserAuthorities();
+
+    static Collection<GrantedAuthority> defaultServiceUserAuthorities() {
+
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("hasRole('" + SERVICE_USER_ROLE + "')"));
+
+        return authorities;
+    }
+
+    static SmartCosmosUser getServiceUser(String username, String password, Collection<GrantedAuthority> authorities) {
+
+        Collection<GrantedAuthority> serviceUserAuthorities = new ArrayList<>();
+        if (authorities == null || authorities.isEmpty()) {
+            serviceUserAuthorities = DEFAULT_SERVICE_USER_AUTHORITIES;
+        } else {
+            serviceUserAuthorities.addAll(authorities);
+        }
+
+        return new SmartCosmosUser(null, null, username, password, serviceUserAuthorities);
+    }
+}

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosServiceUser.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/SmartCosmosServiceUser.java
@@ -8,12 +8,18 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- *
+ * Constant interface for default Service User configuration.
  */
 public interface SmartCosmosServiceUser {
 
+    /**
+     * Name of the service user's role, used for the default authority {@code "hasRole('" + SERVICE_USER_ROLE + "')"}.
+     */
     String SERVICE_USER_ROLE = "ROLE_SMARTCOSMOS_SERVICE_CLIENT";
 
+    /**
+     * The default authorities of a service user.
+     */
     Collection<GrantedAuthority> DEFAULT_SERVICE_USER_AUTHORITIES = defaultServiceUserAuthorities();
 
     static Collection<GrantedAuthority> defaultServiceUserAuthorities() {
@@ -24,6 +30,14 @@ public interface SmartCosmosServiceUser {
         return authorities;
     }
 
+    /**
+     * Creates a new Service User.
+     *
+     * @param username the username, used to verify HTTP Basic Auth
+     * @param password the password, used to verify HTTP Basic Auth
+     * @param authorities the authorities, will override the default authorities
+     * @return the Service User {@link SmartCosmosUser} instance
+     */
     static SmartCosmosUser getServiceUser(String username, String password, Collection<GrantedAuthority> authorities) {
 
         Collection<GrantedAuthority> serviceUserAuthorities = new ArrayList<>();

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/filter/AuthenticationFilter.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Optional;
 
+/**
+ * Custom authentication filter to invoke additional authentication providers in the security filter chain.
+ */
 @Slf4j
 public class AuthenticationFilter extends GenericFilterBean {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/filter/AuthenticationFilter.java
@@ -1,0 +1,87 @@
+package net.smartcosmos.extension.tenant.auth.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import net.smartcosmos.extension.tenant.auth.SmartCosmosServiceUser;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+@Slf4j
+public class AuthenticationFilter extends GenericFilterBean {
+
+    private AuthenticationManager authenticationManager;
+
+    public AuthenticationFilter(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        Optional<String> authorizationHeader = Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION));
+
+        Optional<Authentication> authenticationToken = getAuthentication(authorizationHeader);
+        if (authenticationToken.isPresent()) {
+            Authentication authentication = authenticate(authenticationToken.get());
+            if (authentication.isAuthenticated()) {
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        log.debug("SMART COSMOS AuthenticationFilter is passing request down the filter chain");
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private Optional<Authentication> getAuthentication(Optional<String> authorizationHeader) {
+
+        Authentication authenticationToken = null;
+        if (authorizationHeader.isPresent()) {
+            authenticationToken = getUsernamePasswordToken(authorizationHeader.get());
+        }
+
+        return Optional.ofNullable(authenticationToken);
+    }
+
+    private Authentication getUsernamePasswordToken(String authorization) {
+
+        if (authorization.startsWith("Basic ")) {
+
+            String base64Credentials = authorization.substring("Basic".length()).trim();
+            String credentials = new String(Base64.decodeBase64(base64Credentials), Charset.forName("UTF-8"));
+            final String[] values = credentials.split(":",2);
+
+            SmartCosmosUser serviceUser = SmartCosmosServiceUser.getServiceUser(values[0], values[1], null);
+
+            return new UsernamePasswordAuthenticationToken(serviceUser, values[1]);
+        }
+
+        return null;
+    }
+
+    private Authentication authenticate(Authentication requestAuthentication) {
+
+        Authentication responseAuthentication = authenticationManager.authenticate(requestAuthentication);
+        if (responseAuthentication == null || !responseAuthentication.isAuthenticated()) {
+            throw new InternalAuthenticationServiceException("Unable to authenticate user for provided credentials");
+        }
+        log.debug("User successfully authenticated");
+
+        return responseAuthentication;
+    }
+}

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/provider/ServiceUserAccessAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/provider/ServiceUserAccessAuthenticationProvider.java
@@ -3,7 +3,6 @@ package net.smartcosmos.extension.tenant.auth.provider;
 import net.smartcosmos.extension.tenant.config.ServiceUserProperties;
 import net.smartcosmos.security.user.SmartCosmosUser;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -11,18 +10,37 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 
-@Component
+/**
+ * Implementation of {@link AuthenticationProvider} supporting {@link UsernamePasswordAuthenticationToken} authentication.
+ * <p></p>
+ * This authentication provider is used to verify the {@link UsernamePasswordAuthenticationToken} authentication,
+ * that is based on the HTTP Basic Authorization header of requests sent by Service Users.
+ */
 public class ServiceUserAccessAuthenticationProvider implements AuthenticationProvider {
 
     private static final Class SUPPORTED_AUTHENTICATION = UsernamePasswordAuthenticationToken.class;
 
-    @Autowired
     private ServiceUserProperties serviceUser;
 
+    /**
+     * Creates a new {@link ServiceUserAccessAuthenticationProvider} instance to verify Service User calls based on the provided properties.
+     *
+     * @param serviceUser the Service User properties
+     */
+    public ServiceUserAccessAuthenticationProvider(ServiceUserProperties serviceUser) {
+        this.serviceUser = serviceUser;
+    }
+
+    /**
+     * Verifies a authentication against the stored service user properties.
+     *
+     * @param authentication the requested authentication
+     * @return the successful authentication, or {@code null} if the provider could not verify the authentication
+     * @throws AuthenticationException if the authentication does not match the service user properties
+     */
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 
@@ -54,6 +72,12 @@ public class ServiceUserAccessAuthenticationProvider implements AuthenticationPr
         return null;
     }
 
+    /**
+     * Indicates if the authentication provider supports a given authentication type.
+     *
+     * @param authenticationClass the {@link Authentication} type
+     * @return {@link true} if the authentication provider can verify the type
+     */
     @Override
     public boolean supports(Class<?> authenticationClass) {
         return SUPPORTED_AUTHENTICATION.equals(authenticationClass);

--- a/src/main/java/net/smartcosmos/extension/tenant/auth/provider/ServiceUserAccessAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/auth/provider/ServiceUserAccessAuthenticationProvider.java
@@ -1,18 +1,24 @@
-package net.smartcosmos.extension.tenant.auth;
+package net.smartcosmos.extension.tenant.auth.provider;
 
+import net.smartcosmos.extension.tenant.config.ServiceUserProperties;
+import net.smartcosmos.security.user.SmartCosmosUser;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import net.smartcosmos.extension.tenant.config.ServiceUserProperties;
+import java.util.Collection;
 
 @Component
 public class ServiceUserAccessAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Class SUPPORTED_AUTHENTICATION = UsernamePasswordAuthenticationToken.class;
 
     @Autowired
     private ServiceUserProperties serviceUser;
@@ -26,25 +32,30 @@ public class ServiceUserAccessAuthenticationProvider implements AuthenticationPr
 
         String username = authentication.getName();
         Object credentials = authentication.getCredentials();
+        Object principal = authentication.getPrincipal();
 
-        if (credentials instanceof String) {
+        if (credentials instanceof String && principal instanceof SmartCosmosUser) {
             String password = (String) credentials;
             if (StringUtils.equals(username, serviceUser.getUsername())
                 && StringUtils.equals(password, serviceUser.getPassword())) {
-                return authentication;
+
+                SmartCosmosUser user = (SmartCosmosUser) principal;
+                Collection<GrantedAuthority> authorities = user.getAuthorities();
+
+                return new UsernamePasswordAuthenticationToken(user, credentials, authorities);
             } else {
                 String msg = String.format("Credentials for user '%s' do not match.", authentication.getName());
                 throw new BadCredentialsException(msg);
             }
         }
 
-        // We excpect credentials to be a password String.
+        // We expect credentials to be a password String, and principal needs to be SmartCosmosUser.
         // If they're not, we don't know what to do.
         return null;
     }
 
     @Override
-    public boolean supports(Class<?> aClass) {
-        return true;
+    public boolean supports(Class<?> authenticationClass) {
+        return SUPPORTED_AUTHENTICATION.equals(authenticationClass);
     }
 }

--- a/src/main/java/net/smartcosmos/extension/tenant/config/AnonymousAccessSecurityConfiguration.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/AnonymousAccessSecurityConfiguration.java
@@ -1,5 +1,6 @@
 package net.smartcosmos.extension.tenant.config;
 
+import net.smartcosmos.extension.tenant.auth.SmartCosmosAnonymousUser;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -14,11 +15,19 @@ public class AnonymousAccessSecurityConfiguration extends WebSecurityConfigurerA
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.requestMatchers()
-            .antMatchers("/tenants/**", "/authenticate/**")
+            .antMatchers("/tenants/**")
             .and()
-            .authorizeRequests().antMatchers(HttpMethod.POST, "/tenants").permitAll()
+            .authorizeRequests()
+                .antMatchers(HttpMethod.POST, "/tenants")
+                .permitAll()
             .and()
-            .authorizeRequests().antMatchers(HttpMethod.POST, "/authenticate").permitAll()
+            .authorizeRequests()
+                .anyRequest()
+                .authenticated()
+            .and()
+            .anonymous()
+                .key(SmartCosmosAnonymousUser.ANONYMOUS_AUTHENTICATION_KEY)
+                .principal(SmartCosmosAnonymousUser.ANONYMOUS_USER)
             .and()
             .csrf().disable();
     }

--- a/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
@@ -4,6 +4,7 @@ import net.smartcosmos.extension.tenant.auth.filter.AuthenticationFilter;
 import net.smartcosmos.extension.tenant.auth.provider.ServiceUserAccessAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -19,11 +20,17 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 public class ServiceUserAccessSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
-    private ServiceUserAccessAuthenticationProvider serviceUserAuthProvider;
+    private ServiceUserProperties serviceUserProperties;
+
+    @Bean
+    @Autowired
+    public ServiceUserAccessAuthenticationProvider serviceUserAuthProvider() {
+        return new ServiceUserAccessAuthenticationProvider(serviceUserProperties);
+    }
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.authenticationProvider(serviceUserAuthProvider);
+        auth.authenticationProvider(serviceUserAuthProvider());
     }
 
     @Override

--- a/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
@@ -1,7 +1,7 @@
 package net.smartcosmos.extension.tenant.config;
 
-import net.smartcosmos.extension.tenant.auth.provider.ServiceUserAccessAuthenticationProvider;
 import net.smartcosmos.extension.tenant.auth.filter.AuthenticationFilter;
+import net.smartcosmos.extension.tenant.auth.provider.ServiceUserAccessAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
@@ -31,7 +31,9 @@ public class ServiceUserAccessSecurityConfiguration extends WebSecurityConfigure
         http.requestMatchers()
             .antMatchers("/authenticate/**")
             .and()
-            .authorizeRequests().anyRequest().authenticated();
+            .authorizeRequests().anyRequest().authenticated()
+            .and()
+            .csrf().disable();
 
         http.addFilterBefore(new AuthenticationFilter(authenticationManager()), BasicAuthenticationFilter.class);
     }

--- a/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserAccessSecurityConfiguration.java
@@ -1,5 +1,7 @@
 package net.smartcosmos.extension.tenant.config;
 
+import net.smartcosmos.extension.tenant.auth.provider.ServiceUserAccessAuthenticationProvider;
+import net.smartcosmos.extension.tenant.auth.filter.AuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
@@ -8,8 +10,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-
-import net.smartcosmos.extension.tenant.auth.ServiceUserAccessAuthenticationProvider;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -18,20 +19,20 @@ import net.smartcosmos.extension.tenant.auth.ServiceUserAccessAuthenticationProv
 public class ServiceUserAccessSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
-    private ServiceUserAccessAuthenticationProvider authProvider;
+    private ServiceUserAccessAuthenticationProvider serviceUserAuthProvider;
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.authenticationProvider(authProvider);
+        auth.authenticationProvider(serviceUserAuthProvider);
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.authenticationProvider(authProvider)
-            .csrf().disable()
-            .antMatcher("/authenticate/**")
-            .authorizeRequests().anyRequest().authenticated()
+        http.requestMatchers()
+            .antMatchers("/authenticate/**")
             .and()
-            .httpBasic();
+            .authorizeRequests().anyRequest().authenticated();
+
+        http.addFilterBefore(new AuthenticationFilter(authenticationManager()), BasicAuthenticationFilter.class);
     }
 }

--- a/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserProperties.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserProperties.java
@@ -7,6 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @ConfigurationProperties("smartcosmos.security.resource.user-details")
 public class ServiceUserProperties {
-    private String username;
-    private String password;
+    private String username = "smartcosmosclient";
+    private String password = "LkRv4Z-=caBcx.zX";
 }

--- a/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserProperties.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/config/ServiceUserProperties.java
@@ -1,10 +1,16 @@
 package net.smartcosmos.extension.tenant.config;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @ConfigurationProperties("smartcosmos.security.resource.user-details")
 public class ServiceUserProperties {
     private String username = "smartcosmosclient";

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/authentication/AuthenticationResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/authentication/AuthenticationResource.java
@@ -4,8 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.annotation.SmartCosmosRdao;
 import net.smartcosmos.extension.tenant.rest.dto.authentication.RestAuthenticateRequest;
 import net.smartcosmos.extension.tenant.rest.service.authentication.AuthenticationService;
+import net.smartcosmos.security.user.SmartCosmosUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -29,7 +31,8 @@ public class AuthenticationResource {
 
     @RequestMapping(value = "authenticate", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE,
                     consumes = APPLICATION_JSON_UTF8_VALUE)
-    public ResponseEntity<?> authenticate(@RequestBody @Valid RestAuthenticateRequest authenticate){
-        return authenticationService.authenticate(authenticate);
+    public ResponseEntity<?> authenticate(@RequestBody @Valid RestAuthenticateRequest authenticate,
+                                          @AuthenticationPrincipal SmartCosmosUser user){
+        return authenticationService.authenticate(authenticate, user);
     }
 }

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResource.java
@@ -5,9 +5,11 @@ import net.smartcosmos.annotation.SmartCosmosRdao;
 import net.smartcosmos.extension.tenant.rest.dto.tenant.RestCreateTenantRequest;
 import net.smartcosmos.extension.tenant.rest.service.tenant.CreateTenantService;
 import net.smartcosmos.security.EndpointMethodControl;
+import net.smartcosmos.security.user.SmartCosmosUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -35,9 +37,10 @@ public class CreateTenantResource {
     @EndpointMethodControl(key = "tenant.post")
     @ConditionalOnProperty(prefix = "smt.endpoints.tenant.post", name = "enabled", matchIfMissing = true)
     public DeferredResult<ResponseEntity> createTenant(
-        @RequestBody @Valid RestCreateTenantRequest restCreateTenantRequest) {
+            @RequestBody @Valid RestCreateTenantRequest restCreateTenantRequest,
+            @AuthenticationPrincipal SmartCosmosUser user) {
 
-        return service.create(restCreateTenantRequest);
+        return service.create(restCreateTenantRequest, user);
     }
 }
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.annotation.SmartCosmosRdao;
 import net.smartcosmos.extension.tenant.rest.service.tenant.ReadTenantService;
 import net.smartcosmos.security.EndpointMethodControl;
+import net.smartcosmos.security.user.SmartCosmosUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
@@ -27,16 +28,18 @@ public class ReadTenantResource {
     @RequestMapping(value = "/tenants/{urn}", method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
     @EndpointMethodControl(key = "tenant.urn.get")
     @ConditionalOnProperty(prefix = "smt.endpoints.tenant.urn.get", name = "enabled", matchIfMissing = true)
-    public ResponseEntity<?> getByUrn(@PathVariable String urn) {
+    public ResponseEntity<?> getByUrn(@PathVariable String urn,
+                                      SmartCosmosUser user) {
 
-        return readTenantService.findByUrn(urn);
+        return readTenantService.findByUrn(urn, user);
     }
 
     @RequestMapping(value = "/tenants", method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
     @EndpointMethodControl(key = "tenant.get")
     @ConditionalOnProperty(prefix = "smt.endpoints.tenant.get", name = "enabled", matchIfMissing = true)
-    public ResponseEntity<?> getByName(@RequestParam(value = "name", required = false, defaultValue = "") String name) {
+    public ResponseEntity<?> getByName(@RequestParam(value = "name", required = false, defaultValue = "") String name,
+                                       SmartCosmosUser user) {
 
-        return readTenantService.query(name);
+        return readTenantService.query(name, user);
     }
 }

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/authentication/AuthenticationService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/authentication/AuthenticationService.java
@@ -1,13 +1,5 @@
 package net.smartcosmos.extension.tenant.rest.service.authentication;
 
-import java.util.Optional;
-import javax.inject.Inject;
-
-import org.springframework.core.convert.ConversionService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-
 import net.smartcosmos.events.SmartCosmosEventTemplate;
 import net.smartcosmos.extension.tenant.dao.RoleDao;
 import net.smartcosmos.extension.tenant.dao.TenantDao;
@@ -15,6 +7,14 @@ import net.smartcosmos.extension.tenant.dto.authentication.GetAuthoritiesRespons
 import net.smartcosmos.extension.tenant.rest.dto.authentication.RestAuthenticateRequest;
 import net.smartcosmos.extension.tenant.rest.dto.authentication.RestAuthenticateResponse;
 import net.smartcosmos.extension.tenant.rest.service.AbstractTenantService;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.Optional;
 
 @Service
 public class AuthenticationService extends AbstractTenantService {
@@ -29,7 +29,7 @@ public class AuthenticationService extends AbstractTenantService {
         super(tenantDao, roleDao, smartCosmosEventTemplate, conversionService);
     }
 
-    public ResponseEntity<?> authenticate(RestAuthenticateRequest authenticate) {
+    public ResponseEntity<?> authenticate(RestAuthenticateRequest authenticate, SmartCosmosUser user) {
 
         Optional<GetAuthoritiesResponse> entity = tenantDao.getAuthorities(authenticate.getName(), authenticate.getCredentials());
         if (entity.isPresent()) {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/ReadTenantService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/ReadTenantService.java
@@ -8,6 +8,7 @@ import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.tenant.TenantResponse;
 import net.smartcosmos.extension.tenant.rest.dto.tenant.RestTenantResponse;
 import net.smartcosmos.extension.tenant.rest.service.AbstractTenantService;
+import net.smartcosmos.security.user.SmartCosmosUser;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.ResponseEntity;
@@ -31,34 +32,34 @@ public class ReadTenantService extends AbstractTenantService {
         super(tenantDao, roleDao, smartCosmosEventTemplate, conversionService);
     }
 
-    public ResponseEntity<?> findByUrn(String urn) {
+    public ResponseEntity<?> findByUrn(String urn, SmartCosmosUser user) {
 
         Optional<TenantResponse> entity = tenantDao.findTenantByUrn(urn);
 
         if (entity.isPresent()) {
-            sendEvent(null, DefaultEventTypes.TenantRead, entity.get());
+            sendEvent(user, DefaultEventTypes.TenantRead, entity.get());
             return ResponseEntity
                 .ok()
                 .body(conversionService.convert(entity.get(), RestTenantResponse.class));
         }
 
-        sendEvent(null, DefaultEventTypes.TenantNotFound, urn);
+        sendEvent(user, DefaultEventTypes.TenantNotFound, urn);
         return ResponseEntity.notFound().build();
     }
 
-    public ResponseEntity<?> query(String name) {
+    public ResponseEntity<?> query(String name, SmartCosmosUser user) {
         if (StringUtils.isBlank(name)) {
-            return findAll();
+            return findAll(user);
         } else {
-            return findByName(name);
+            return findByName(name, user);
         }
     }
 
-    public ResponseEntity<?> findAll() {
+    public ResponseEntity<?> findAll(SmartCosmosUser user) {
 
         List<TenantResponse> tenantList = tenantDao.findAllTenants();
         for (TenantResponse tenant : tenantList) {
-            sendEvent(null, DefaultEventTypes.TenantRead, tenant);
+            sendEvent(user, DefaultEventTypes.TenantRead, tenant);
         }
 
         return ResponseEntity
@@ -66,18 +67,18 @@ public class ReadTenantService extends AbstractTenantService {
                 .body(convertList(tenantList, TenantResponse.class, RestTenantResponse.class));
     }
 
-    public ResponseEntity<?> findByName(String name) {
+    public ResponseEntity<?> findByName(String name, SmartCosmosUser user) {
 
         Optional<TenantResponse> entity = tenantDao.findTenantByName(name);
 
         if (entity.isPresent()) {
-            sendEvent(null, DefaultEventTypes.TenantRead, entity.get());
+            sendEvent(user, DefaultEventTypes.TenantRead, entity.get());
             return ResponseEntity
                 .ok()
                 .body(conversionService.convert(entity.get(), RestTenantResponse.class));
         }
 
-        sendEvent(null, DefaultEventTypes.TenantNotFound, name);
+        sendEvent(user, DefaultEventTypes.TenantNotFound, name);
         return ResponseEntity.notFound().build();
     }
 }

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/AbstractTestResource.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/AbstractTestResource.java
@@ -3,7 +3,6 @@ package net.smartcosmos.extension.tenant.rest.resource;
 import net.smartcosmos.extension.tenant.TenantRdao;
 import net.smartcosmos.extension.tenant.dao.RoleDao;
 import net.smartcosmos.extension.tenant.dao.TenantDao;
-import net.smartcosmos.security.user.SmartCosmosUser;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -17,20 +16,17 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.mock.http.MockHttpOutputMessage;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 /**
  * Unit Testing sample for creating Tenants and Users.
@@ -62,17 +58,10 @@ public abstract class AbstractTestResource {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(getClass());
 
-        // Need to mock out user for conversion service.
-        // Might be a good candidate for a test package util.
-        Authentication authentication = Mockito.mock(Authentication.class);
-        Mockito.when(authentication.getPrincipal())
-            .thenReturn(new SmartCosmosUser("accountUrn", "urn:userUrn", "username",
-                                            "password", Arrays.asList(new SimpleGrantedAuthority("USER"))));
-        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
-        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-
-        this.mockMvc = webAppContextSetup(webApplicationContext).build();
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
     }
 
     protected String json(Object o) throws IOException {

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/AbstractTestResource.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/AbstractTestResource.java
@@ -3,6 +3,7 @@ package net.smartcosmos.extension.tenant.rest.resource;
 import net.smartcosmos.extension.tenant.TenantRdao;
 import net.smartcosmos.extension.tenant.dao.RoleDao;
 import net.smartcosmos.extension.tenant.dao.TenantDao;
+import org.apache.commons.codec.binary.Base64;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -69,6 +70,13 @@ public abstract class AbstractTestResource {
         this.mappingJackson2HttpMessageConverter.write(o, MediaType.APPLICATION_JSON,
                                                        mockHttpOutputMessage);
         return mockHttpOutputMessage.getBodyAsString();
+    }
+
+    protected String basicAuth(String username, String password) {
+
+        byte[] bytes = (username + ":" + password).getBytes();
+
+        return "Basic " + Base64.encodeBase64String(bytes);
     }
 
     @Configuration

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/auth/AuthenticationResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/auth/AuthenticationResourceTest.java
@@ -1,16 +1,17 @@
 package net.smartcosmos.extension.tenant.rest.resource.auth;
 
-import java.util.Arrays;
-import java.util.Optional;
-
-import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
-import org.junit.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.web.servlet.MvcResult;
-
 import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.authentication.GetAuthoritiesResponse;
 import net.smartcosmos.extension.tenant.rest.dto.authentication.RestAuthenticateRequest;
+import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -18,9 +19,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 public class AuthenticationResourceTest extends AbstractTestResource {
 
@@ -33,7 +32,70 @@ public class AuthenticationResourceTest extends AbstractTestResource {
     }
 
     @Test
-    public void thatAuthenticationSucceeds() throws Exception {
+    public void thatAuthenticationWithServiceUserSucceeds() throws Exception {
+
+        RestAuthenticateRequest request = RestAuthenticateRequest.builder()
+            .name("username")
+            .credentials("password")
+            .build();
+
+
+        String[] authorities = {"https://authorities.smartcosmos.net/things/read", "https://authorities.smartcosmos.net/things/write"};
+
+        GetAuthoritiesResponse response1 = GetAuthoritiesResponse.builder()
+            .urn("urn")
+            .tenantUrn("tenantUrn")
+            .username("username")
+            .authorities(Arrays.asList(authorities))
+            .build();
+        Optional<GetAuthoritiesResponse> response = Optional.of(response1);
+
+        when(tenantDao.getAuthorities(anyString(), anyString())).thenReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmosclient", "LkRv4Z-=caBcx.zX"))
+                .content(json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.userUrn", is("urn")))
+            .andExpect(jsonPath("$.username", is("username")))
+            .andExpect(jsonPath("$.tenantUrn", is("tenantUrn")))
+            .andExpect(jsonPath("$.authorities", hasSize(2)))
+            .andExpect(jsonPath("$.authorities[0]", is("https://authorities.smartcosmos.net/things/read")))
+            .andExpect(jsonPath("$.authorities[1]", is("https://authorities.smartcosmos.net/things/write")))
+            .andExpect(jsonPath("$.authorities").isArray())
+            .andReturn();
+
+        verify(tenantDao, times(1)).getAuthorities(anyString(), anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    public void thatAuthenticationUnauthorizedWithServiceUserFails() throws Exception {
+
+        RestAuthenticateRequest request = RestAuthenticateRequest.builder()
+            .name("invalid")
+            .credentials("invalid")
+            .build();
+
+        when(tenantDao.getAuthorities(anyString(), anyString())).thenReturn(Optional.empty());
+
+        MvcResult mvcResult = mockMvc.perform(
+            post("/authenticate")
+                .header(HttpHeaders.AUTHORIZATION, basicAuth("smartcosmosclient", "LkRv4Z-=caBcx.zX"))
+                .content(json(request))
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isUnauthorized())
+            .andReturn();
+
+        verify(tenantDao, times(1)).getAuthorities(anyString(), anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    public void thatAuthenticationWithoutServiceUserFails() throws Exception {
 
         RestAuthenticateRequest request = RestAuthenticateRequest.builder()
             .name("username")
@@ -57,23 +119,15 @@ public class AuthenticationResourceTest extends AbstractTestResource {
             post("/authenticate")
                 .content(json(request))
                 .contentType(APPLICATION_JSON_UTF8))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
-            .andExpect(jsonPath("$.userUrn", is("urn")))
-            .andExpect(jsonPath("$.username", is("username")))
-            .andExpect(jsonPath("$.tenantUrn", is("tenantUrn")))
-            .andExpect(jsonPath("$.authorities", hasSize(2)))
-            .andExpect(jsonPath("$.authorities[0]", is("https://authorities.smartcosmos.net/things/read")))
-            .andExpect(jsonPath("$.authorities[1]", is("https://authorities.smartcosmos.net/things/write")))
-            .andExpect(jsonPath("$.authorities").isArray())
+            .andExpect(status().isForbidden())
             .andReturn();
 
-        verify(tenantDao, times(1)).getAuthorities(anyString(), anyString());
+        verify(tenantDao, times(0)).getAuthorities(anyString(), anyString());
         verifyNoMoreInteractions(tenantDao);
     }
 
     @Test
-    public void thatAuthenticationUnauthorizedFails() throws Exception {
+    public void thatAuthenticationUnauthorizedWithoutServiceUserFails() throws Exception {
 
         RestAuthenticateRequest request = RestAuthenticateRequest.builder()
             .name("invalid")
@@ -86,10 +140,10 @@ public class AuthenticationResourceTest extends AbstractTestResource {
             post("/authenticate")
                 .content(json(request))
                 .contentType(APPLICATION_JSON_UTF8))
-            .andExpect(status().isUnauthorized())
+            .andExpect(status().isForbidden())
             .andReturn();
 
-        verify(tenantDao, times(1)).getAuthorities(anyString(), anyString());
+        verify(tenantDao, times(0)).getAuthorities(anyString(), anyString());
         verifyNoMoreInteractions(tenantDao);
     }
 

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResourceTest.java
@@ -6,6 +6,7 @@ import net.smartcosmos.extension.tenant.dto.role.RoleResponse;
 import net.smartcosmos.extension.tenant.rest.dto.role.RestCreateOrUpdateRoleRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class CreateRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResourceTest.java
@@ -5,6 +5,7 @@ import net.smartcosmos.extension.tenant.dao.RoleDao;
 import net.smartcosmos.extension.tenant.dto.role.RoleResponse;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class DeleteRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResourceTest.java
@@ -4,6 +4,7 @@ import net.smartcosmos.extension.tenant.dao.RoleDao;
 import net.smartcosmos.extension.tenant.dto.role.RoleResponse;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@WithMockSmartCosmosUser
 public class ReadRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResourceTest.java
@@ -6,6 +6,7 @@ import net.smartcosmos.extension.tenant.dto.role.RoleResponse;
 import net.smartcosmos.extension.tenant.rest.dto.role.RestCreateOrUpdateRoleRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class UpdateRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResourceTest.java
@@ -8,6 +8,7 @@ import net.smartcosmos.extension.tenant.dto.user.CreateUserResponse;
 import net.smartcosmos.extension.tenant.rest.dto.tenant.RestCreateTenantRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +53,8 @@ public class CreateTenantResourceTest extends AbstractTestResource {
      * @throws Exception
      */
     @Test
-    public void thatCreateTenantSucceeds() throws Exception {
+    @WithMockSmartCosmosUser
+    public void thatCreateTenantWithUserSucceeds() throws Exception {
 
         final String name = "example.com";
         final String username = "spam@example.com";
@@ -106,6 +108,64 @@ public class CreateTenantResourceTest extends AbstractTestResource {
             .andExpect(jsonPath("$.admin.roles").isArray())
             .andExpect(jsonPath("$.admin.tenantUrn", startsWith("urn:tenant:uuid")))
             .andExpect(jsonPath("$.admin.urn", startsWith("urn:user:uuid")));
+
+    }
+
+    @Test
+    public void thatCreateTenantUnAuthenticatedSucceeds() throws Exception {
+
+        final String name = "example.com";
+        final String username = "spam@example.com";
+        final String password = "ChangeMe";
+
+        final String expectedTenantUrn = "urn:tenant:uuid:" + UuidUtil.getNewUuid()
+                .toString();
+
+        final String expectedUserUrn = "urn:user:uuid:" + UuidUtil.getNewUuid()
+                .toString();
+
+        Set<String> adminRoles = new HashSet<>();
+        adminRoles.add("Admin");
+
+        CreateUserResponse createUserResponse = CreateUserResponse.builder()
+                .urn(expectedUserUrn)
+                .username(username)
+                .password(password)
+                .roles(adminRoles)
+                .tenantUrn(expectedTenantUrn)
+                .build();
+
+        CreateTenantResponse createTenantResponse = CreateTenantResponse.builder()
+                .urn(expectedTenantUrn)
+                .admin(createUserResponse)
+                .build();
+
+        when(tenantDao.createTenant(anyObject())).thenReturn(Optional.ofNullable(createTenantResponse));
+
+        RestCreateTenantRequest request = RestCreateTenantRequest.builder()
+                .name(name)
+                .username(username)
+                .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+                post("/tenants").content(this.json(request))
+                        .contentType(contentType))
+                .andExpect(status().isOk())
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        this.mockMvc.perform(asyncDispatch(mvcResult))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(contentType))
+                .andExpect(jsonPath("$.urn", startsWith("urn:tenant:uuid")))
+                .andExpect(jsonPath("$.name").doesNotExist())
+                .andExpect(jsonPath("$.admin").isMap())
+                .andExpect(jsonPath("$.admin.emailAddress").doesNotExist())
+                .andExpect(jsonPath("$.admin.username", is(username)))
+                .andExpect(jsonPath("$.admin.password", is(password)))
+                .andExpect(jsonPath("$.admin.roles").isArray())
+                .andExpect(jsonPath("$.admin.tenantUrn", startsWith("urn:tenant:uuid")))
+                .andExpect(jsonPath("$.admin.urn", startsWith("urn:user:uuid")));
 
     }
 }

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
@@ -4,6 +4,7 @@ import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.tenant.TenantResponse;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +15,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
@@ -33,6 +33,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetByUrnSucceeds() throws Exception {
 
         String name = "getByUrn";
@@ -61,6 +62,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetByUnknownUrnFails() throws Exception {
 
         String urn = UuidUtil.getTenantUrnFromUuid(UuidUtil.getNewUuid());
@@ -79,6 +81,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetByNameSucceeds() throws Exception {
 
         String name = "getByName";
@@ -109,6 +112,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetByUnknownNameFails() throws Exception {
 
         String name = "noSuchTenant";
@@ -129,6 +133,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetAllNoTenantSucceeds() throws Exception {
 
         List<TenantResponse> response = new ArrayList<>();
@@ -148,6 +153,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser
     public void thatGetAllTenantSucceeds() throws Exception {
 
         List<TenantResponse> response = new ArrayList<>();

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
@@ -62,6 +62,20 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    public void thatGetByUrnAnonymousFails() throws Exception {
+
+        String urn = "accountUrn"; // Tenant URN from AbstractTestResource
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants/{urn}", urn).contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findTenantByUrn(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
     @WithMockSmartCosmosUser
     public void thatGetByUnknownUrnFails() throws Exception {
 
@@ -77,6 +91,20 @@ public class ReadTenantResourceTest extends AbstractTestResource {
             .andReturn();
 
         verify(tenantDao, times(1)).findTenantByUrn(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    public void thatGetByUnknownUrnAnonymousFails() throws Exception {
+
+        String urn = UuidUtil.getTenantUrnFromUuid(UuidUtil.getNewUuid());
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants/{urn}", urn).contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findTenantByUrn(anyString());
         verifyNoMoreInteractions(tenantDao);
     }
 
@@ -112,6 +140,22 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    public void thatGetByNameAnonymousFails() throws Exception {
+
+        String name = "getByName";
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants")
+                        .param("name", name)
+                        .contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findTenantByName(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
     @WithMockSmartCosmosUser
     public void thatGetByUnknownNameFails() throws Exception {
 
@@ -133,6 +177,22 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
+    public void thatGetByUnknownNameAnonymousFails() throws Exception {
+
+        String name = "noSuchTenant";
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants")
+                        .param("name", name)
+                        .contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findTenantByName(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
     @WithMockSmartCosmosUser
     public void thatGetAllNoTenantSucceeds() throws Exception {
 
@@ -149,6 +209,19 @@ public class ReadTenantResourceTest extends AbstractTestResource {
                 .andReturn();
 
         verify(tenantDao, times(1)).findAllTenants();
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    public void thatGetAllNoTenantAnonymousFails() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants")
+                        .contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findAllTenants();
         verifyNoMoreInteractions(tenantDao);
     }
 
@@ -181,6 +254,19 @@ public class ReadTenantResourceTest extends AbstractTestResource {
                 .andReturn();
 
         verify(tenantDao, times(1)).findAllTenants();
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    public void thatGetAllTenantAnonymousFails() throws Exception {
+
+        MvcResult mvcResult = mockMvc.perform(
+                get("/tenants")
+                        .contentType(APPLICATION_JSON_UTF8))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(tenantDao, times(0)).findAllTenants();
         verifyNoMoreInteractions(tenantDao);
     }
 }

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
@@ -34,7 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class,
                                             TenantPersistenceConfig.class })
-@WithMockSmartCosmosUser
 public class UpdateTenantResourceTest extends AbstractTestResource {
 
     @Autowired
@@ -51,6 +50,7 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
      * @throws Exception
      */
     @Test
+    @WithMockSmartCosmosUser
     public void thatUpdateTenantSucceeds() throws Exception {
 
         final String name = "example.com";
@@ -90,6 +90,7 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
      * @throws Exception
      */
     @Test
+    @WithMockSmartCosmosUser
     public void thatUpdateNonexistentTenantFails() throws Exception {
 
         final String name = "example.com";

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
@@ -7,6 +7,7 @@ import net.smartcosmos.extension.tenant.dto.tenant.TenantResponse;
 import net.smartcosmos.extension.tenant.rest.dto.tenant.RestUpdateTenantRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class,
                                             TenantPersistenceConfig.class })
+@WithMockSmartCosmosUser
 public class UpdateTenantResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
@@ -117,4 +117,53 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
                 .andExpect(status().isNotFound())
                 .andReturn();
     }
+
+    @Test
+    public void thatUpdateTenantAnonymousFails() throws Exception {
+
+        final String name = "example.com";
+        final Boolean active = false;
+
+        final String expectedTenantUrn = "urn:tenant:uuid:" + UuidUtil.getNewUuid()
+                .toString();
+
+        RestUpdateTenantRequest request = RestUpdateTenantRequest.builder()
+                .active(active)
+                .name(name)
+                .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+                put("/tenants/{urn}", expectedTenantUrn).content(this.json(request))
+                        .contentType(contentType))
+                .andExpect(status().isForbidden())
+                .andExpect(request().asyncStarted())
+                .andReturn();
+    }
+
+    /**
+     * Test that updating a nonexistent Tenant fails.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void thatUpdateNonexistentTenantAnonymousFails() throws Exception {
+
+        final String name = "example.com";
+        final Boolean active = false;
+
+        final String expectedTenantUrn = "urn:tenant:uuid:" + UuidUtil.getNewUuid()
+                .toString();
+
+        RestUpdateTenantRequest request = RestUpdateTenantRequest.builder()
+                .active(active)
+                .name(name)
+                .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+                put("/tenants/{urn}", expectedTenantUrn).content(this.json(request))
+                        .contentType(contentType))
+                .andExpect(status().isForbidden())
+                .andExpect(request().asyncNotStarted())
+                .andReturn();
+    }
 }

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
@@ -136,7 +136,7 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
                 put("/tenants/{urn}", expectedTenantUrn).content(this.json(request))
                         .contentType(contentType))
                 .andExpect(status().isForbidden())
-                .andExpect(request().asyncStarted())
+                .andExpect(request().asyncNotStarted())
                 .andReturn();
     }
 

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResourceTest.java
@@ -6,6 +6,7 @@ import net.smartcosmos.extension.tenant.dto.user.CreateUserResponse;
 import net.smartcosmos.extension.tenant.rest.dto.user.RestCreateOrUpdateUserRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class CreateUserResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResourceTest.java
@@ -5,6 +5,7 @@ import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class DeleteUserResourceTest extends AbstractTestResource {
 
     private String tenantUrn;

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
@@ -4,6 +4,7 @@ import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@WithMockSmartCosmosUser
 public class ReadUserResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResourceTest.java
@@ -6,6 +6,7 @@ import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 import net.smartcosmos.extension.tenant.rest.dto.user.RestCreateOrUpdateUserRequest;
 import net.smartcosmos.extension.tenant.rest.resource.AbstractTestResource;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
+import net.smartcosmos.test.security.WithMockSmartCosmosUser;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SuppressWarnings("Duplicates")
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
+@WithMockSmartCosmosUser
 public class UpdateUserResourceTest extends AbstractTestResource {
 
     @Autowired


### PR DESCRIPTION
### What changes were proposed in this pull request?
#### Important bugfix

The previous version of `AnonymousAccessSecurityConfiguration` enabled anonymous access to **all endpoints** with the path `/tenants/**`, instead of just the `POST` endpoint.
#### Test Improvements
- uses the new `@WithMockSmartCosmosUser` for testing
- adds tests to ensure only `POST /tenants` can be anonymously accessed
- adds utility method to set `Authorization` headers
#### Anonymous User Access / Event Improvements

Even the anonymous access user is now an instance of `SmartCosmosUser`, so that there isn't any request without an "authenticated" user. Yes, even the anonymous user is a somewhat authenticated user with username `ANONYMOUS`, but this principal isn't associated to any tenant and also has no URN. This user's only default authority is `hasRole("ROLE_ANONYMOUS")`.

All parameters for the anonymous user can be set in `SmartCosmosAnonymousUser`.
#### Service User Access

With this pull request, it also becomes possible to use service users with HTTP Basic Authentication to restrict access to service endpoints that are not intended to be used by "real" users, like `POST /authenticate`.

The service user credentials are read from the service configuration.

It is possible to use multiple instances of the `ServiceUserAccessAuthenticationProvider` as long as they are separately configured, so that it is possible to use different HTTP Basic credentials for different endpoints.

Slight modification of `ServiceUserProperties` and the authentication provider would even allow for custom authority sets for different service users.
### How is this patch documented?

Code, Javadoc.
### How was this patch tested?

Unit tests, added additionally one to test if creating tenants works with authentication and without.
#### Depends On

Nothing.
