### PR TITLE
Move authorities to constants in interface, add missing authorities

### DIFF
--- a/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
@@ -1,22 +1,42 @@
 package net.smartcosmos.extension.tenant.dao;
 
+import java.util.List;
+import java.util.Optional;
+import javax.validation.ConstraintViolationException;
+
 import net.smartcosmos.extension.tenant.dto.authentication.GetAuthoritiesResponse;
 import net.smartcosmos.extension.tenant.dto.tenant.CreateTenantRequest;
 import net.smartcosmos.extension.tenant.dto.tenant.CreateTenantResponse;
 import net.smartcosmos.extension.tenant.dto.tenant.TenantResponse;
 import net.smartcosmos.extension.tenant.dto.tenant.UpdateTenantRequest;
 import net.smartcosmos.extension.tenant.dto.user.CreateOrUpdateUserRequest;
-import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 import net.smartcosmos.extension.tenant.dto.user.CreateUserResponse;
-
-import javax.validation.ConstraintViolationException;
-import java.util.List;
-import java.util.Optional;
+import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 
 /**
  * Initially created by SMART COSMOS Team on June 30, 2016.
  */
 public interface TenantDao {
+
+    String[] DEFAULT_ADMIN_AUTHORITIES = {
+        "https://authorities.smartcosmos.net/things/create",
+        "https://authorities.smartcosmos.net/things/read",
+        "https://authorities.smartcosmos.net/things/update",
+        "https://authorities.smartcosmos.net/things/delete",
+        "https://authorities.smartcosmos.net/metadata/create",
+        "https://authorities.smartcosmos.net/metadata/read",
+        "https://authorities.smartcosmos.net/metadata/update",
+        "https://authorities.smartcosmos.net/metadata/delete",
+        "https://authorities.smartcosmos.net/relationships/create",
+        "https://authorities.smartcosmos.net/relationships/read",
+        "https://authorities.smartcosmos.net/relationships/delete"
+    };
+
+    String[] DEFAULT_USER_AUTHORITIES = {
+        "https://authorities.smartcosmos.net/things/read",
+        "https://authorities.smartcosmos.net/metadata/read",
+        "https://authorities.smartcosmos.net/relationships/read",
+    };
 
     Optional<CreateTenantResponse> createTenant(CreateTenantRequest tenantCreate) throws ConstraintViolationException;
 

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
@@ -1,6 +1,22 @@
 package net.smartcosmos.extension.tenant.impl;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.ConstraintViolationException;
+
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionException;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.stereotype.Service;
+
 import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.domain.AuthorityEntity;
 import net.smartcosmos.extension.tenant.domain.RoleEntity;
@@ -22,14 +38,6 @@ import net.smartcosmos.extension.tenant.repository.TenantRepository;
 import net.smartcosmos.extension.tenant.repository.UserRepository;
 import net.smartcosmos.extension.tenant.util.MergeUtil;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.ConversionException;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.stereotype.Service;
-
-import javax.validation.ConstraintViolationException;
-import java.util.*;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -402,18 +410,13 @@ public class TenantPersistenceService implements TenantDao {
     // region UTILITY METHODS
 
     private RoleEntity createAdminRole(String tenantUrn) {
-        List<String> authorities = new ArrayList<>();
-        authorities.add("https://authorities.smartcosmos.net/things/read");
-        authorities.add("https://authorities.smartcosmos.net/things/write");
 
-        return createRole(tenantUrn, "Admin", authorities);
+        return createRole(tenantUrn, "Admin", Arrays.asList(DEFAULT_ADMIN_AUTHORITIES));
     }
 
     private RoleEntity createUserRole(String tenantUrn) {
-        List<String> authorities = new ArrayList<>();
-        authorities.add("https://authorities.smartcosmos.net/things/read");
 
-        return createRole(tenantUrn, "User", authorities);
+        return createRole(tenantUrn, "User", Arrays.asList(DEFAULT_USER_AUTHORITIES));
     }
 
     private RoleEntity createRole(String tenantUrn, String name, List<String> authorities) {

--- a/src/test/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceServiceTest.java
@@ -1,7 +1,22 @@
 package net.smartcosmos.extension.tenant.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
 import net.smartcosmos.extension.tenant.TenantPersistenceConfig;
 import net.smartcosmos.extension.tenant.TenantPersistenceTestApplication;
+import net.smartcosmos.extension.tenant.dao.TenantDao;
 import net.smartcosmos.extension.tenant.dto.authentication.GetAuthoritiesResponse;
 import net.smartcosmos.extension.tenant.dto.tenant.CreateTenantRequest;
 import net.smartcosmos.extension.tenant.dto.tenant.CreateTenantResponse;
@@ -13,21 +28,6 @@ import net.smartcosmos.extension.tenant.dto.user.UserResponse;
 import net.smartcosmos.extension.tenant.repository.TenantRepository;
 import net.smartcosmos.extension.tenant.repository.UserRepository;
 import net.smartcosmos.extension.tenant.util.UuidUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.Assert.*;
 
@@ -488,7 +488,7 @@ public class TenantPersistenceServiceTest {
         assertTrue(authorities.isPresent());
         assertNotNull(authorities.get().getPasswordHash());
         assertFalse(authorities.get().getAuthorities().isEmpty());
-        assertEquals(2, authorities.get().getAuthorities().size());
+        assertEquals(TenantDao.DEFAULT_ADMIN_AUTHORITIES.length, authorities.get().getAuthorities().size());
         assertTrue(authorities.get().getAuthorities().contains("https://authorities.smartcosmos.net/things/read"));
         assertTrue(authorities.get().getAuthorities().contains("https://authorities.smartcosmos.net/things/read"));
     }
@@ -543,9 +543,9 @@ public class TenantPersistenceServiceTest {
         assertTrue(authorities.isPresent());
         assertNotNull(authorities.get().getPasswordHash());
         assertFalse(authorities.get().getAuthorities().isEmpty());
-        assertEquals(2, authorities.get().getAuthorities().size());
+        assertEquals(TenantDao.DEFAULT_ADMIN_AUTHORITIES.length, authorities.get().getAuthorities().size());
         assertTrue(authorities.get().getAuthorities().contains("https://authorities.smartcosmos.net/things/read"));
-        assertTrue(authorities.get().getAuthorities().contains("https://authorities.smartcosmos.net/things/write"));
+        assertTrue(authorities.get().getAuthorities().contains("https://authorities.smartcosmos.net/things/create"));
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change adds the default authorities as a constant array to the `TenantDao` interface.

Previously missing authorities are added, so that newly created users have the common authorities for Objects TRM.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

Nothing.
