### PR TITLE
Solves issue with invalid topics in later versions of Kafka.

### DIFF
--- a/src/main/java/net/smartcosmos/extension/tenant/rest/utility/RoleEventType.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/utility/RoleEventType.java
@@ -4,12 +4,12 @@ import org.apache.commons.lang.StringUtils;
 
 public enum RoleEventType {
 
-    ROLE_CREATED("role:created"),
-    ROLE_READ("role:read"),
-    ROLE_CREATE_FAILED_ALREADY_EXISTS("role:createFailedAlreadyExists"),
-    ROLE_NOT_FOUND("role:notFound"),
-    ROLE_DELETED("role:deleted"),
-    ROLE_UPDATED("role:updated"),
+    ROLE_CREATED("role.created"),
+    ROLE_READ("role.read"),
+    ROLE_CREATE_FAILED_ALREADY_EXISTS("role.createFailedAlreadyExists"),
+    ROLE_NOT_FOUND("role.notFound"),
+    ROLE_DELETED("role.deleted"),
+    ROLE_UPDATED("role.updated"),
     UNKNOWN("Unknown");
 
     private String eventName;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/utility/TenantEventType.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/utility/TenantEventType.java
@@ -4,12 +4,12 @@ import org.apache.commons.lang.StringUtils;
 
 public enum TenantEventType {
 
-    TENANT_READ("tenant:read"),
-    TENANT_CONFIRMED("tenant:confirmed"),
-    TENANT_CREATED("tenant:created"),
-    TENANT_UPDATED("tenant:updated"),
-    TENANT_CREATE_FAILED_ALREADY_EXISTS("tenant:createFailedAlreadyExists"),
-    TENANT_NOT_FOUND("tenant:notFound"),
+    TENANT_READ("tenant.read"),
+    TENANT_CONFIRMED("tenant.confirmed"),
+    TENANT_CREATED("tenant.created"),
+    TENANT_UPDATED("tenant.updated"),
+    TENANT_CREATE_FAILED_ALREADY_EXISTS("tenant.createFailedAlreadyExists"),
+    TENANT_NOT_FOUND("tenant.notFound"),
     UNKNOWN("Unknown");
 
     private String eventName;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/utility/UserEventType.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/utility/UserEventType.java
@@ -4,19 +4,19 @@ import org.apache.commons.lang.StringUtils;
 
 public enum UserEventType {
 
-    USER_READ("user:read"),
-    USER_BATCH_START("user:batch:start"),
-    USER_BATCH_STOP("user:batch:stop"),
-    USER_CREATED("user:created"),
-    USER_LOGIN_FAILURE("user:login:failure"),
-    USER_LOGIN_SUCCESS("user:login:success"),
-    USER_PASSWORD_CHANGED("user:password:changed"),
-    USER_PASSWORD_RESET("user:password:reset"),
-    USER_REGISTRATION_REQUEST("user:registration:requested"),
-    USER_UPDATED("user:updated"),
-    USER_CREATE_FAILED_ALREADY_EXISTS("user:createFailedAlreadyExists"),
-    USER_DELETED("user:deleted"),
-    USER_NOT_FOUND("user:notFound"),
+    USER_READ("user.read"),
+    USER_BATCH_START("user.batch.start"),
+    USER_BATCH_STOP("user.batch.stop"),
+    USER_CREATED("user.created"),
+    USER_LOGIN_FAILURE("user.login.failure"),
+    USER_LOGIN_SUCCESS("user.login.success"),
+    USER_PASSWORD_CHANGED("user.password.changed"),
+    USER_PASSWORD_RESET("user.password.reset"),
+    USER_REGISTRATION_REQUEST("user.registration.requested"),
+    USER_UPDATED("user.updated"),
+    USER_CREATE_FAILED_ALREADY_EXISTS("user.createFailedAlreadyExists"),
+    USER_DELETED("user.deleted"),
+    USER_NOT_FOUND("user.notFound"),
     UNKNOWN("Unknown");
 
     private String eventName;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Later versions of Kafka consider `:` to be invalid for topics names.
