### PR TITLE
Feature/objects 923 authorities

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= REST Implementations for User Edge Microservice
+= REST Implementations for User Management Edge Microservice
 SMARTRAC Technology Fletcher Inc <api@smartrac-group.com>
 :version: 3.0.0-SNAPSHOT
 ifdef::env-github[:USER: SMARTRACTECHNOLOGY]
@@ -9,6 +9,27 @@ Microservice which provides basic management functionality for tenants, user and
 
 == License
 This is a private licensed repository, and as such, should not be shared publicly.
+
+== Authorities
+
+=== Tenant Authorities
+
+- https://authorities.smartcosmos.net/tenants/read
+- https://authorities.smartcosmos.net/tenants/update
+
+=== User Authorities
+
+- https://authorities.smartcosmos.net/users/create
+- https://authorities.smartcosmos.net/users/read
+- https://authorities.smartcosmos.net/users/update
+- https://authorities.smartcosmos.net/users/delete
+
+=== Role Authorities
+
+- https://authorities.smartcosmos.net/roles/create
+- https://authorities.smartcosmos.net/roles/read
+- https://authorities.smartcosmos.net/roles/update
+- https://authorities.smartcosmos.net/roles/delete
 
 == REST API
 

--- a/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
@@ -28,14 +28,27 @@ public interface TenantDao {
         "https://authorities.smartcosmos.net/metadata/delete",
         "https://authorities.smartcosmos.net/relationships/create",
         "https://authorities.smartcosmos.net/relationships/read",
-        "https://authorities.smartcosmos.net/relationships/delete"
+        "https://authorities.smartcosmos.net/relationships/delete",
+        "https://authorities.smartcosmos.net/tenants/read",
+        "https://authorities.smartcosmos.net/tenants/update",
+        "https://authorities.smartcosmos.net/users/create",
+        "https://authorities.smartcosmos.net/users/read",
+        "https://authorities.smartcosmos.net/users/update",
+        "https://authorities.smartcosmos.net/users/delete",
+        "https://authorities.smartcosmos.net/roles/create",
+        "https://authorities.smartcosmos.net/roles/read",
+        "https://authorities.smartcosmos.net/roles/update",
+        "https://authorities.smartcosmos.net/roles/delete"
     };
 
     String[] DEFAULT_USER_AUTHORITIES = {
         "https://authorities.smartcosmos.net/things/read",
         "https://authorities.smartcosmos.net/metadata/read",
         "https://authorities.smartcosmos.net/relationships/read",
-        };
+        "https://authorities.smartcosmos.net/tenants/read",
+        "https://authorities.smartcosmos.net/users/read",
+        "https://authorities.smartcosmos.net/roles/read"
+    };
 
     Optional<CreateTenantResponse> createTenant(CreateTenantRequest tenantCreate) throws ConstraintViolationException;
 

--- a/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/dao/TenantDao.java
@@ -45,9 +45,6 @@ public interface TenantDao {
         "https://authorities.smartcosmos.net/things/read",
         "https://authorities.smartcosmos.net/metadata/read",
         "https://authorities.smartcosmos.net/relationships/read",
-        "https://authorities.smartcosmos.net/tenants/read",
-        "https://authorities.smartcosmos.net/users/read",
-        "https://authorities.smartcosmos.net/roles/read"
     };
 
     Optional<CreateTenantResponse> createTenant(CreateTenantRequest tenantCreate) throws ConstraintViolationException;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -30,6 +31,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.role.RoleEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_ROLES, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/roles/create')")
 //@Api
 public class CreateRoleResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -26,6 +27,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.role.RoleEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_ROLES, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/roles/delete')")
 //@Api
 public class DeleteRoleResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -28,6 +29,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.role.RoleEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_ROLES, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/roles/read')")
 public class ReadRoleResource {
 
     private ReadRoleService service;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.role.RoleEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_ROLES, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/roles/update')")
 //@Api
 public class UpdateRoleResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/CreateTenantResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +32,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.tenant.TenantEndpoi
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_TENANTS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("permitAll()")
 //@Api
 public class CreateTenantResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -28,6 +29,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.tenant.TenantEndpoi
 @Slf4j
 @SmartCosmosRdao
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_TENANTS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/tenants/read')")
 public class ReadTenantResource {
 
     private ReadTenantService readTenantService;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResource.java
@@ -39,11 +39,12 @@ public class ReadTenantResource {
 
     @RequestMapping(value = ENDPOINT_TENANTS_URN, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
     @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_TENANTS_READ_URN, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+    @PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/tenants/read') or #tenantUrn.equals(#user.getAccountUrn())")
     public ResponseEntity<?> getByUrn(
-        @PathVariable(TENANT_URN) String urn,
+        @PathVariable(TENANT_URN) String tenantUrn,
         SmartCosmosUser user) {
 
-        return readTenantService.findByUrn(urn, user);
+        return readTenantService.findByUrn(tenantUrn, user);
     }
 
     @RequestMapping(value = ENDPOINT_TENANTS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.tenant.TenantEndpoi
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_TENANTS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/tenants/update')")
 //@Api
 public class UpdateTenantResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -30,6 +31,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/create')")
 //@Api
 public class CreateUserResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -26,6 +27,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/delete')")
 //@Api
 public class DeleteUserResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -28,6 +29,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @Slf4j
 @SmartCosmosRdao
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/read')")
 public class ReadUserResource {
 
     private ReadUserService readUserService;

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
@@ -29,7 +29,6 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @Slf4j
 @SmartCosmosRdao
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
-@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/read')")
 public class ReadUserResource {
 
     private ReadUserService readUserService;
@@ -49,6 +48,7 @@ public class ReadUserResource {
 
     @RequestMapping(value = ENDPOINT_USERS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
     @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS_READ_ALL, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+    @PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/read') or #name.equals(#user.getUsername())")
     public ResponseEntity<?> getByName(
         @RequestParam(value = NAME, required = false, defaultValue = "") String name,
         SmartCosmosUser user) {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResource.java
@@ -39,11 +39,12 @@ public class ReadUserResource {
 
     @RequestMapping(value = ENDPOINT_USERS_URN, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
     @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS_READ_URN, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+    @PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/read') or #userUrn.equals(#user.getUserUrn())")
     public ResponseEntity<?> getByUrn(
-        @PathVariable(USER_URN) String urn,
+        @PathVariable(USER_URN) String userUrn,
         SmartCosmosUser user) {
 
-        return readUserService.findByUrn(urn, user);
+        return readUserService.findByUrn(userUrn, user);
     }
 
     @RequestMapping(value = ENDPOINT_USERS, method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResource.java
@@ -33,7 +33,6 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
-@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/update')")
 //@Api
 public class UpdateUserResource {
 
@@ -47,12 +46,17 @@ public class UpdateUserResource {
                     produces = APPLICATION_JSON_UTF8_VALUE,
                     consumes = APPLICATION_JSON_UTF8_VALUE)
     @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS_UPDATE, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+    @PreAuthorize(
+        "hasAuthority('https://authorities.smartcosmos.net/users/update') "
+        + "or (#userUrn.equals(#user.getUserUrn()) and (#requestBody.roles == null or #requestBody.roles.size() == 0))")
     public DeferredResult<ResponseEntity> updateUser(
         @PathVariable(USER_URN) String userUrn,
         @RequestBody @Valid RestCreateOrUpdateUserRequest requestBody,
         SmartCosmosUser user) {
 
-        return service.update(userUrn, requestBody, user);
+        DeferredResult<ResponseEntity> response = new DeferredResult<>();
+        service.update(response, userUrn, requestBody, user);
+        return response;
     }
 }
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResource.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResource.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,7 @@ import static net.smartcosmos.extension.tenant.rest.resource.user.UserEndpointCo
 @SmartCosmosRdao
 @Slf4j
 @ConditionalOnProperty(prefix = ENDPOINT_ENABLEMENT_USERS, name = ENDPOINT_ENABLEMENT_PROPERTY_ENABLED, matchIfMissing = true)
+@PreAuthorize("hasAuthority('https://authorities.smartcosmos.net/users/update')")
 //@Api
 public class UpdateUserResource {
 

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/CreateRoleService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/CreateRoleService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -50,7 +49,6 @@ public class CreateRoleService {
         return response;
     }
 
-    @Async
     private void createRoleWorker(
         DeferredResult<ResponseEntity> response, String tenantUrn, RestCreateOrUpdateRoleRequest
         roleRequest, SmartCosmosUser user) {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/DeleteRoleService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/DeleteRoleService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -44,7 +43,6 @@ public class DeleteRoleService {
         return response;
     }
 
-    @Async
     private void deleteRoleWorker(DeferredResult<ResponseEntity> response, SmartCosmosUser user, String roleUrn) {
 
         try {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/UpdateRoleService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/role/UpdateRoleService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -48,7 +47,6 @@ public class UpdateRoleService {
         return response;
     }
 
-    @Async
     private void updateRoleWorker(
         DeferredResult<ResponseEntity> response,
         String roleUrn,

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/CreateTenantService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/CreateTenantService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -51,7 +50,6 @@ public class CreateTenantService {
         return response;
     }
 
-    @Async
     private void createTenantWorker(DeferredResult<ResponseEntity> response, RestCreateTenantRequest restCreateTenantRequest, SmartCosmosUser user) {
 
         try {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/UpdateTenantService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/tenant/UpdateTenantService.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -48,7 +47,6 @@ public class UpdateTenantService {
         return response;
     }
 
-    @Async
     private void updateTenantWorker(
         DeferredResult<ResponseEntity> response,
         SmartCosmosUser user,

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/user/CreateUserService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/user/CreateUserService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -50,7 +49,6 @@ public class CreateUserService {
         return response;
     }
 
-    @Async
     private void createUserWorker(
         DeferredResult<ResponseEntity> response, SmartCosmosUser user, RestCreateOrUpdateUserRequest
         restCreateUserRequest) {

--- a/src/main/java/net/smartcosmos/extension/tenant/rest/service/user/DeleteUserService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/rest/service/user/DeleteUserService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -47,7 +46,6 @@ public class DeleteUserService {
         return response;
     }
 
-    @Async
     private void deleteUserWorker(DeferredResult<ResponseEntity> response, SmartCosmosUser user, String userUrn) {
 
         try {

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/CreateRoleResourceTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { DevKitUserManagementService.class, UserManagementPersistenceConfig.class,
                                                                           UserDetailsPersistenceConfig.class })
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/roles/create" })
 public class CreateRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/DeleteRoleResourceTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Unit Testing sample for deleting Roles.
  */
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/roles/delete" })
 public class DeleteRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/ReadRoleResourceTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/roles/read" })
 public class ReadRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/role/UpdateRoleResourceTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Unit Testing sample for updating Roles.
  */
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/roles/update" })
 public class UpdateRoleResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/ReadTenantResourceTest.java
@@ -37,11 +37,40 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetByUrnSucceeds() throws Exception {
 
         String name = "getByUrn";
         String urn = "accountUrn"; // Tenant URN from AbstractTestResource
+
+        TenantResponse response1 = TenantResponse.builder()
+            .active(true)
+            .name(name)
+            .urn(urn)
+            .build();
+        Optional<TenantResponse> response = Optional.of(response1);
+
+        when(tenantDao.findTenantByUrn(anyString())).thenReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(
+            get("/tenants/{urn}", urn).contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.active", is(true)))
+            .andExpect(jsonPath("$.name", is(name)))
+            .andExpect(jsonPath("$.urn", is(urn)))
+            .andReturn();
+
+        verify(tenantDao, times(1)).findTenantByUrn(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(tenantUrn = "myOwnTenantUrn", authorities = {})
+    public void thatGetByOwnUrnSucceeds() throws Exception {
+
+        String name = "getByUrn";
+        String urn = "myOwnTenantUrn";
 
         TenantResponse response1 = TenantResponse.builder()
             .active(true)
@@ -80,7 +109,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetByUnknownUrnFails() throws Exception {
 
         String urn = UuidUtil.getTenantUrnFromUuid(UuidUtil.getNewUuid());
@@ -113,7 +142,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetByNameSucceeds() throws Exception {
 
         String name = "getByName";
@@ -160,7 +189,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetByUnknownNameFails() throws Exception {
 
         String name = "noSuchTenant";
@@ -197,7 +226,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetAllNoTenantSucceeds() throws Exception {
 
         List<TenantResponse> response = new ArrayList<>();
@@ -230,7 +259,7 @@ public class ReadTenantResourceTest extends AbstractTestResource {
     }
 
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/read" })
     public void thatGetAllTenantSucceeds() throws Exception {
 
         List<TenantResponse> response = new ArrayList<>();

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/tenant/UpdateTenantResourceTest.java
@@ -49,7 +49,7 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
      * @throws Exception
      */
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/update" })
     public void thatUpdateTenantSucceeds() throws Exception {
 
         final String name = "example.com";
@@ -89,7 +89,7 @@ public class UpdateTenantResourceTest extends AbstractTestResource {
      * @throws Exception
      */
     @Test
-    @WithMockSmartCosmosUser
+    @WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/tenants/update" })
     public void thatUpdateNonexistentTenantFails() throws Exception {
 
         final String name = "example.com";

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/CreateUserResourceTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Unit Testing sample for creating Users.
  */
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/users/create" })
 public class CreateUserResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/DeleteUserResourceTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Unit Testing sample for deleting Users.
  */
 @org.springframework.boot.test.SpringApplicationConfiguration(classes = { TenantPersistenceTestApplication.class })
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/users/delete" })
 public class DeleteUserResourceTest extends AbstractTestResource {
 
     private String tenantUrn;

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
@@ -80,6 +80,49 @@ public class ReadUserResourceTest extends AbstractTestResource {
     }
 
     @Test
+    @WithMockSmartCosmosUser(authorities = {}, usernUrn = "myOwnUrn")
+    public void thatGetByOwnUrnSucceeds() throws Exception {
+
+        String name = "getByUrn";
+        String urn = "myOwnUrn";
+        String tenantUrn = UuidUtil.getTenantUrnFromUuid(UuidUtil.getNewUuid());
+        String emailAddress = "getByUrn@example.com";
+        Boolean active = true;
+        String givenName = "John";
+        String surname = "Doe";
+
+        UserResponse response1 = UserResponse.builder()
+            .active(active)
+            .username(name)
+            .emailAddress(emailAddress)
+            .urn(urn)
+            .tenantUrn(tenantUrn)
+            .givenName(givenName)
+            .surname(surname)
+            .build();
+        Optional<UserResponse> response = Optional.of(response1);
+
+        when(tenantDao.findUserByUrn(anyString(), anyString())).thenReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(
+            get("/users/{urn}", urn).contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.active", is(active)))
+            .andExpect(jsonPath("$.givenName", is(givenName)))
+            .andExpect(jsonPath("$.surname", is(surname)))
+            .andExpect(jsonPath("$.emailAddress", is(emailAddress)))
+            .andExpect(jsonPath("$.username", is(name)))
+            .andExpect(jsonPath("$.urn", is(urn)))
+            .andExpect(jsonPath("$.tenantUrn", is(tenantUrn)))
+            .andExpect(jsonPath("$.roles").isArray())
+            .andReturn();
+
+        verify(tenantDao, times(1)).findUserByUrn(anyString(), anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
     public void thatGetByUrnFails() throws Exception {
 
         String urn = UuidUtil.getUserUrnFromUuid(UuidUtil.getNewUuid());
@@ -94,6 +137,40 @@ public class ReadUserResourceTest extends AbstractTestResource {
             .andReturn();
 
         verify(tenantDao, times(1)).findUserByUrn(anyString(), anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(authorities = {}, username = "myOwnName")
+    public void thatGetByOwnNameSucceeds() throws Exception {
+
+        String name = "myOwnName";
+        String urn = UuidUtil.getUserUrnFromUuid(UuidUtil.getNewUuid());
+        String tenantUrn = UuidUtil.getTenantUrnFromUuid(UuidUtil.getNewUuid());
+
+        UserResponse response1 = UserResponse.builder()
+            .active(true)
+            .username(name)
+            .urn(urn)
+            .tenantUrn(tenantUrn)
+            .build();
+        Optional<UserResponse> response = Optional.of(response1);
+
+        when(tenantDao.findUserByName(anyString(), anyString())).thenReturn(response);
+
+        MvcResult mvcResult = mockMvc.perform(
+            get("/users")
+                .param("name", name)
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+            .andExpect(jsonPath("$.active", is(true)))
+            .andExpect(jsonPath("$.username", is(name)))
+            .andExpect(jsonPath("$.urn", is(urn)))
+            .andExpect(jsonPath("$.tenantUrn", is(tenantUrn)))
+            .andReturn();
+
+        verify(tenantDao, times(1)).findUserByName(anyString(), anyString());
         verifyNoMoreInteractions(tenantDao);
     }
 
@@ -178,6 +255,19 @@ public class ReadUserResourceTest extends AbstractTestResource {
             .andReturn();
 
         verify(tenantDao, times(1)).findAllUsers(anyString());
+        verifyNoMoreInteractions(tenantDao);
+    }
+
+    @Test
+    @WithMockSmartCosmosUser
+    public void thatFindAllUsersInTenantWithoutAuthorityFails() throws Exception {
+        
+        MvcResult mvcResult = mockMvc.perform(
+            get("/users")
+                .contentType(APPLICATION_JSON_UTF8))
+            .andExpect(status().isForbidden())
+            .andReturn();
+
         verifyNoMoreInteractions(tenantDao);
     }
 }

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/ReadUserResourceTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WithMockSmartCosmosUser
+@WithMockSmartCosmosUser(authorities = { "https://authorities.smartcosmos.net/users/read" })
 public class ReadUserResourceTest extends AbstractTestResource {
 
     @Autowired

--- a/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResourceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/rest/resource/user/UpdateUserResourceTest.java
@@ -152,6 +152,37 @@ public class UpdateUserResourceTest extends AbstractTestResource {
             .andReturn();
     }
 
+    @Test
+    @WithMockSmartCosmosUser(authorities = {}, usernUrn = "myOwnUrn")
+    public void thatUpdateOwnRoleFails() throws Exception {
+
+        String ownUrn = "myOwnUrn";
+        String username = "newUser";
+        String emailAddress = "newUser@example.com";
+
+        final String expectedTenantUrn = "urn:tenant:uuid:" + UuidUtil.getNewUuid()
+            .toString();
+
+        final String expectedUserUrn = ownUrn;
+
+        List<String> userRoles = new ArrayList<>();
+        userRoles.add("Admin");
+
+        RestCreateOrUpdateUserRequest request = RestCreateOrUpdateUserRequest.builder()
+            .username(username)
+            .emailAddress(emailAddress)
+            .roles(userRoles)
+            .build();
+
+        MvcResult mvcResult = this.mockMvc.perform(
+            put("/users/{urn}", expectedUserUrn)
+                .content(this.json(request))
+                .contentType(contentType))
+            .andExpect(status().isForbidden())
+            .andExpect(request().asyncNotStarted())
+            .andReturn();
+    }
+
     /**
      * Test that updating a nonexistent User fails.
      *


### PR DESCRIPTION
### What changes were proposed in this pull request?
- adds authorities and `@PreAuthorize` annotations

This change restricts user management capabilities to `Admin` users, who get the required authorities by default. Without the required authorities, `User` users can only do the following:
- read their own tenant by URN
- read their own user by name or URN
- update their own user (except roles)
### How is this patch documented?

Code.
### How was this patch tested?

Existing and additional unit tests.
#### Depends On

Nothing.
