### PR TITLE
using org.apache.commons.lang.RandomStringUtils.randomAlphanumeric(8)…

### DIFF
--- a/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
@@ -50,8 +50,6 @@ public class TenantPersistenceService implements TenantDao {
     private final RoleRepository roleRepository;
     private final ConversionService conversionService;
 
-    private static final String INITIAL_PASSWORD = RandomStringUtils.randomAlphanumeric(8);
-
     /**
      * @param tenantRepository
      * @param userRepository
@@ -110,7 +108,7 @@ public class TenantPersistenceService implements TenantDao {
                 .tenantId(tenantEntity.getId())
                 .username(createTenantRequest.getUsername())
                 .emailAddress(createTenantRequest.getUsername())
-                .password(INITIAL_PASSWORD)
+                .password(RandomStringUtils.randomAlphanumeric(8))
                 .roles(roles)
                 .active(createTenantRequest.getActive() == null ? true : createTenantRequest.getActive())
                 .build();
@@ -246,7 +244,7 @@ public class TenantPersistenceService implements TenantDao {
             return Optional.empty();
         }
 
-        String password = INITIAL_PASSWORD;
+        String password = RandomStringUtils.randomAlphanumeric(8);
 
         try {
             UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/TenantPersistenceService.java
@@ -10,6 +10,7 @@ import javax.validation.ConstraintViolationException;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionException;
 import org.springframework.core.convert.ConversionService;
@@ -49,7 +50,7 @@ public class TenantPersistenceService implements TenantDao {
     private final RoleRepository roleRepository;
     private final ConversionService conversionService;
 
-    private static final String INITIAL_PASSWORD = "PleaseChangeMeImmediately";
+    private static final String INITIAL_PASSWORD = RandomStringUtils.randomAlphanumeric(8);
 
     /**
      * @param tenantRepository


### PR DESCRIPTION
### What changes were proposed in this pull request?

using org.apache.commons.lang.RandomStringUtils.randomAlphanumeric(8) to generate initial tenant password

### How is this patch documented?

code - line 53 in TenantPersistenceService.java

### How was this patch tested?

Existing unit tests

#### Depends On

nothing