### PR TITLE
Removes unused libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct</artifactId>
-                <version>1.0.0.Final</version>
-            </dependency>
-            <dependency>
                 <groupId>net.smartcosmos</groupId>
                 <artifactId>smartcosmos-database-devkit</artifactId>
                 <version>3.0.1-SNAPSHOT</version>
@@ -88,11 +83,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adding org.json:json to test phase only has caused consequences in the past, this removes that.  As well as removing mapstruct, which is not used in this service.
