### PR TITLE
Add @EnableSmartCosmosMonitoring

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === New Features
 
-No new features are added in this release.
+* OBJECTS-980 Add Prometheus-compatible `/metrics` endpoint
 
 === Bugfixes & Improvements
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-monitoring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-user-entity-devkit</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/net/smartcosmos/extension/tenant/DevKitUserManagementService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/DevKitUserManagementService.java
@@ -13,6 +13,7 @@ import net.smartcosmos.extension.tenant.config.AnonymousAccessSecurityConfigurat
 
 @EnableSmartCosmosExtension
 @EnableSmartCosmosEvents
+@EnableSmartCosmosMonitoring
 //@EnableSmartCosmosSecurity
 @ComponentScan
 @Import(AnonymousAccessSecurityConfiguration.class)

--- a/src/main/java/net/smartcosmos/extension/tenant/DevKitUserManagementService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/DevKitUserManagementService.java
@@ -9,6 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import net.smartcosmos.annotation.EnableSmartCosmosEvents;
 import net.smartcosmos.annotation.EnableSmartCosmosExtension;
+import net.smartcosmos.annotation.EnableSmartCosmosMonitoring;
 import net.smartcosmos.extension.tenant.config.AnonymousAccessSecurityConfiguration;
 
 @EnableSmartCosmosExtension


### PR DESCRIPTION
### What changes were proposed in this pull request?

adds the `@EnableSmartCosmosMonitoring` annotation which adds a new `/metrics` endpoint for Prometheus 

### How is this patch documented?

- Code
- Javadoc in Framework

### How was this patch tested?

manually

#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/196