### PR TITLE
role names also get updated in role updates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@
 * OBJECTS-991 User Creation throws NullPointerException
 * PROFILES-667: add zipkin starter for distributed tracing
 * reduces un-used complexity regarding Spring Security
+* OBJECTS-1153 Updates to Roles were not updating Role name.
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
@@ -83,7 +83,7 @@ public class RolePersistenceService implements RoleDao {
         // This role name already exists in a different role? we're not doing the update
         Optional<RoleEntity> existingRole = roleRepository.findByTenantIdAndNameIgnoreCase(UuidUtil.getUuidFromUrn(tenantUrn),
                                                                                            updateRoleRequest.getName());
-        if (existingRole.isPresent() && existingRole.get().getId() != id) {
+        if (existingRole.isPresent() && existingRole.get().getId().equals(id)) {
             return Optional.empty();
         }
 

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
@@ -83,7 +83,7 @@ public class RolePersistenceService implements RoleDao {
         // This role name already exists in a different role? we're not doing the update
         Optional<RoleEntity> existingRole = roleRepository.findByTenantIdAndNameIgnoreCase(UuidUtil.getUuidFromUrn(tenantUrn),
                                                                                            updateRoleRequest.getName());
-        if (existingRole.isPresent() && id.equals(existingRole.get().getId()) {
+        if (existingRole.isPresent() && id.equals(existingRole.get().getId())) {
             return Optional.empty();
         }
 

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
@@ -83,7 +83,7 @@ public class RolePersistenceService implements RoleDao {
         // This role name already exists in a different role? we're not doing the update
         Optional<RoleEntity> existingRole = roleRepository.findByTenantIdAndNameIgnoreCase(UuidUtil.getUuidFromUrn(tenantUrn),
                                                                                            updateRoleRequest.getName());
-        if (existingRole.isPresent() && existingRole.get().getId().equals(id)) {
+        if (existingRole.isPresent() && id.equals(existingRole.get().getId()) {
             return Optional.empty();
         }
 

--- a/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/extension/tenant/impl/RolePersistenceService.java
@@ -80,6 +80,13 @@ public class RolePersistenceService implements RoleDao {
         UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
         UUID id = UuidUtil.getUuidFromUrn(urn);
 
+        // This role name already exists in a different role? we're not doing the update
+        Optional<RoleEntity> existingRole = roleRepository.findByTenantIdAndNameIgnoreCase(UuidUtil.getUuidFromUrn(tenantUrn),
+                                                                                           updateRoleRequest.getName());
+        if (existingRole.isPresent() && existingRole.get().getId() != id) {
+            return Optional.empty();
+        }
+
         // Cancel update if role doesn't exist
         if (roleRepository.findByTenantIdAndId(tenantId, id)
             .isPresent()) {

--- a/src/test/java/net/smartcosmos/extension/tenant/impl/RolePersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/extension/tenant/impl/RolePersistenceServiceTest.java
@@ -82,6 +82,7 @@ public class RolePersistenceServiceTest {
     public void thatUpdateRoleSucceeds() {
 
         final String roleName = "updateTestRole";
+        final String newRoleName = "updateTestNewRoleName";
         final String authority1 = "testAuth1";
         final String authority2 = "testAuth2";
 
@@ -91,14 +92,14 @@ public class RolePersistenceServiceTest {
         CreateOrUpdateRoleRequest createRole = CreateOrUpdateRoleRequest.builder()
             .active(true)
             .authorities(authorities)
-            .name(roleName)
+            .name(newRoleName)
             .build();
 
         Optional<RoleResponse> createResponse = rolePersistenceService
             .createRole(tenantRoleTest, createRole);
 
         assertTrue(createResponse.isPresent());
-        assertEquals(roleName,
+        assertEquals(newRoleName,
                      createResponse.get()
                          .getName());
         assertEquals(1,
@@ -128,6 +129,65 @@ public class RolePersistenceServiceTest {
                      updateResponse.get()
                          .getAuthorities()
                          .size());
+    }
+
+    @Test
+    public void thatUpdateRoleFailsWhenNameAlreadyExistsForDifferentRole() {
+
+        final String roleName1 = "updateTestRole1";
+        final String authority1 = "testAuth1";
+
+        final String roleName2 = "updateTestRole1";
+        final String authority2 = "testAuth2";
+
+        List<String> authorities1 = new ArrayList<>();
+        authorities1.add(authority1);
+
+        List<String> authorities2 = new ArrayList<>();
+        authorities2.add(authority2);
+
+        CreateOrUpdateRoleRequest createRole1 = CreateOrUpdateRoleRequest.builder()
+            .active(true)
+            .authorities(authorities1)
+            .name(roleName1)
+            .build();
+
+        CreateOrUpdateRoleRequest createRole2 = CreateOrUpdateRoleRequest.builder()
+            .active(true)
+            .authorities(authorities2)
+            .name(roleName2)
+            .build();
+
+        Optional<RoleResponse> createResponse1 = rolePersistenceService
+            .createRole(tenantRoleTest, createRole1);
+
+        Optional<RoleResponse> createResponse2 = rolePersistenceService
+            .createRole(tenantRoleTest, createRole2);
+
+        assertTrue(createResponse1.isPresent());
+        assertEquals(roleName1,
+                     createResponse1.get()
+                         .getName());
+        assertEquals(1,
+                     createResponse1.get()
+                         .getAuthorities()
+                         .size());
+
+        String urn = createResponse1.get()
+            .getUrn();
+
+        authorities1.add(authority2);
+
+        CreateOrUpdateRoleRequest updateRole = CreateOrUpdateRoleRequest.builder()
+            .active(true)
+            .authorities(authorities1)
+            .name(roleName2)
+            .build();
+
+        Optional<RoleResponse> updateResponse = rolePersistenceService
+            .updateRole(tenantRoleTest, urn, updateRole);
+
+        assertFalse(updateResponse.isPresent());
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Checks against a Role name being used by another role before updating a Role's name.

### How is this patch documented?

in code (RolePersistenceService::updateRole()) and matching tests.

### How was this patch tested?

The existing successful update test now tests name updates, which it didn't before,
and there is an additional test to verify that update fails when another Role already
has the incoming name.

#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit/pull/7
which allows name updates in RoleRepository.java @Column annotation.
