### PR TITLE
Comment event sending on tenant creation, add TODO

### DIFF
--- a/src/main/java/net/smartcosmos/usermanagement/tenant/service/CreateTenantServiceDefault.java
+++ b/src/main/java/net/smartcosmos/usermanagement/tenant/service/CreateTenantServiceDefault.java
@@ -18,9 +18,6 @@ import net.smartcosmos.usermanagement.tenant.dto.CreateTenantRequest;
 import net.smartcosmos.usermanagement.tenant.dto.CreateTenantResponse;
 import net.smartcosmos.usermanagement.tenant.persistence.TenantDao;
 
-import static net.smartcosmos.usermanagement.event.TenantEventType.TENANT_CREATED;
-import static net.smartcosmos.usermanagement.event.TenantEventType.TENANT_CREATE_FAILED_ALREADY_EXISTS;
-
 /**
  * Initially created by SMART COSMOS Team on July 01, 2016.
  */
@@ -64,11 +61,18 @@ public class CreateTenantServiceDefault implements CreateTenantService {
 
         Optional<CreateTenantResponse> createTenantResponse = tenantDao.createTenant(createTenantRequest);
 
+        /**
+         * TODO: Use client authentication instead of user's access token from the request context, because there isn't any for tenant creation
+         * requests (OBJECTS-1213)
+         * author: asiegel
+         * date: 17 Jan 2017
+         */
+
         if (createTenantResponse.isPresent()) {
-            eventSendingService.sendEvent(user, TENANT_CREATED, createTenantResponse.get());
+            //            eventSendingService.sendEvent(user, TENANT_CREATED, createTenantResponse.get());
             return buildCreatedResponseEntity(createTenantResponse.get());
         } else {
-            eventSendingService.sendEvent(user, TENANT_CREATE_FAILED_ALREADY_EXISTS, createTenantRequest);
+            //            eventSendingService.sendEvent(user, TENANT_CREATE_FAILED_ALREADY_EXISTS, createTenantRequest);
             return ResponseEntity.status(HttpStatus.CONFLICT)
                 .build();
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fix avoids the exception response returned when sending the event after tenant creation failed due to a missing access token in the request context.

Although sending the event can never have worked before, because there never was a token in the request context, the problem first occurred after refactoring. Before, the `ResponseEntity` was set before attempting to send the event, which probably is why we had a successful REST response. We didn't realize no event was sent, if it was even tried.

Note that this is not a solution to the problem. It's just a hotfix to make tenant creation return the REST response again.

### How is this patch documented?

TODO comment in the affected method.

### How was this patch tested?

Existing tests pass, also a manual test in Postman was successful.

#### Depends On

Nothing.