### PR TITLE
Bugfix/objects 1214

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@
 * OBJECTS-1153 Updates to Roles were not updating Role name.
 * OBJECTS-1197 Edge User DevKit returns Tenant URN with "user" prefix at tenant creation
 * OBJECTS-1198 Change Password in Edge User DevKit doesn't work
+* OBJECTS-1214 Update Role doesn't work
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/usermanagement/role/persistence/RoleDao.java
+++ b/src/main/java/net/smartcosmos/usermanagement/role/persistence/RoleDao.java
@@ -32,13 +32,14 @@ public interface RoleDao {
      * @param urn URN of role to be updated
      * @param updateRoleRequest changed properties of role
      * @return the updated role or Optional.empty() in case of failure
-     * @throws ConstraintViolationException
+     * @throws ConstraintViolationException in case data constraints are violated
+     * @throws IllegalArgumentException if the role name shall be changed to a name already taken
      */
     Optional<RoleResponse> updateRole(
         String tenantUrn,
         String urn,
         RoleRequest updateRoleRequest)
-        throws ConstraintViolationException;
+        throws ConstraintViolationException, IllegalArgumentException;
 
     /**
      * Find a role identified by their name in the given tenant.

--- a/src/main/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceService.java
@@ -22,6 +22,8 @@ import net.smartcosmos.usermanagement.role.dto.RoleRequest;
 import net.smartcosmos.usermanagement.role.dto.RoleResponse;
 import net.smartcosmos.usermanagement.role.repository.AuthorityRepository;
 
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
 /**
  * Initially created by SMART COSMOS Team on June 30, 2016.
  */
@@ -74,16 +76,13 @@ public class RolePersistenceService implements RoleDao {
 
     @Override
     public Optional<RoleResponse> updateRole(String tenantUrn, String urn, RoleRequest updateRoleRequest)
-        throws ConstraintViolationException {
+        throws ConstraintViolationException, IllegalArgumentException {
 
         UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
         UUID id = UuidUtil.getUuidFromUrn(urn);
 
-        // This role name already exists in a different role? we're not doing the update
-        Optional<RoleEntity> existingRole = roleRepository.findByTenantIdAndNameIgnoreCase(UuidUtil.getUuidFromUrn(tenantUrn),
-                                                                                           updateRoleRequest.getName());
-        if (existingRole.isPresent() && !id.equals(existingRole.get().getId())) {
-            return Optional.empty();
+        if (isNotBlank(updateRoleRequest.getName()) && findRoleByName(tenantUrn, updateRoleRequest.getName()).isPresent()) {
+            throw new IllegalArgumentException(String.format("Can not update role. Name '%s' is already in use.", updateRoleRequest.getName()));
         }
 
         // Cancel update if role doesn't exist

--- a/src/main/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceService.java
+++ b/src/main/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceService.java
@@ -81,8 +81,12 @@ public class RolePersistenceService implements RoleDao {
         UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
         UUID id = UuidUtil.getUuidFromUrn(urn);
 
-        if (isNotBlank(updateRoleRequest.getName()) && findRoleByName(tenantUrn, updateRoleRequest.getName()).isPresent()) {
-            throw new IllegalArgumentException(String.format("Can not update role. Name '%s' is already in use.", updateRoleRequest.getName()));
+        if (isNotBlank(updateRoleRequest.getName())) {
+            Optional<RoleResponse> existingRole = findRoleByName(tenantUrn, updateRoleRequest.getName());
+            if (existingRole.isPresent() && !urn.equals(existingRole.get()
+                                                            .getUrn())) {
+                throw new IllegalArgumentException(String.format("Can not update role. Name '%s' is already in use.", updateRoleRequest.getName()));
+            }
         }
 
         // Cancel update if role doesn't exist

--- a/src/main/java/net/smartcosmos/usermanagement/util/ResponseFactory.java
+++ b/src/main/java/net/smartcosmos/usermanagement/util/ResponseFactory.java
@@ -1,0 +1,71 @@
+package net.smartcosmos.usermanagement.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+/**
+ * Utility class to build {@link ResponseEntity} instances the user management service may return.
+ */
+public class ResponseFactory {
+
+    protected static final String MESSAGE = "message";
+
+    // region Success Responses 2xx
+
+    /**
+     * Builds a 204 No Content response without a response body.
+     *
+     * @return the response entity
+     */
+    public static ResponseEntity<?> noContentResponse() {
+
+        return ResponseEntity.noContent()
+            .build();
+    }
+
+    // endregion
+
+    // region Client Error Responses 4xx
+
+    /**
+     * Builds a 404 Not Found response without a response body.
+     *
+     * @return the response entity
+     */
+    public static ResponseEntity<?> notFoundResponse() {
+
+        return ResponseEntity.notFound()
+            .build();
+    }
+
+    /**
+     * <p>Builds a conflict response that may include an error message:</p>
+     * <pre>{ "message": [message] }</pre>
+     * <p>If no message is provided, and empty body is returned.</p>
+     *
+     * @param message the message
+     * @return the response entity
+     */
+    public static ResponseEntity<?> conflictResponse(String message) {
+
+        ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.status(HttpStatus.CONFLICT);
+
+        if (isBlank(message)) {
+            return responseBuilder.build();
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put(MESSAGE, message);
+        return responseBuilder.contentType(MediaType.APPLICATION_JSON_UTF8)
+            .body(body);
+    }
+
+    // endregion
+
+}

--- a/src/test/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceServiceTest.java
@@ -128,6 +128,58 @@ public class RolePersistenceServiceTest {
                          .size());
     }
 
+    @Test
+    public void thatUpdateRoleSucceedsWithSameName() {
+
+        final String roleName = "updateTestRole2";
+        final String authority1 = "testAuth1";
+        final String authority2 = "testAuth2";
+
+        List<String> authorities = new ArrayList<>();
+        authorities.add(authority1);
+
+        RoleRequest createRole = RoleRequest.builder()
+            .active(true)
+            .authorities(authorities)
+            .name(roleName)
+            .build();
+
+        Optional<RoleResponse> createResponse = rolePersistenceService
+            .createRole(tenantRoleTest, createRole);
+
+        assertTrue(createResponse.isPresent());
+        assertEquals(roleName,
+                     createResponse.get()
+                         .getName());
+        assertEquals(1,
+                     createResponse.get()
+                         .getAuthorities()
+                         .size());
+
+        String urn = createResponse.get()
+            .getUrn();
+
+        authorities.add(authority2);
+
+        RoleRequest updateRole = RoleRequest.builder()
+            .active(true)
+            .authorities(authorities)
+            .name(roleName)
+            .build();
+
+        Optional<RoleResponse> updateResponse = rolePersistenceService
+            .updateRole(tenantRoleTest, urn, updateRole);
+
+        assertTrue(updateResponse.isPresent());
+        assertEquals(roleName,
+                     updateResponse.get()
+                         .getName());
+        assertEquals(2,
+                     updateResponse.get()
+                         .getAuthorities()
+                         .size());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void thatUpdateRoleFailsWhenNameAlreadyExistsForDifferentRole() {
 

--- a/src/test/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/usermanagement/role/persistence/RolePersistenceServiceTest.java
@@ -128,7 +128,7 @@ public class RolePersistenceServiceTest {
                          .size());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void thatUpdateRoleFailsWhenNameAlreadyExistsForDifferentRole() {
 
         final String roleName1 = "updateTestRole1";
@@ -181,10 +181,7 @@ public class RolePersistenceServiceTest {
             .name(roleName2)
             .build();
 
-        Optional<RoleResponse> updateResponse = rolePersistenceService
-            .updateRole(tenantRoleTest, urn, updateRole);
-
-        assertFalse(updateResponse.isPresent());
+        rolePersistenceService.updateRole(tenantRoleTest, urn, updateRole);
     }
 
     @Test

--- a/src/test/java/net/smartcosmos/usermanagement/util/ResponseFactoryTest.java
+++ b/src/test/java/net/smartcosmos/usermanagement/util/ResponseFactoryTest.java
@@ -1,0 +1,142 @@
+package net.smartcosmos.usermanagement.util;
+
+import java.util.Map;
+
+import org.junit.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.Assert.*;
+
+import static net.smartcosmos.usermanagement.util.ResponseFactory.MESSAGE;
+import static net.smartcosmos.usermanagement.util.ResponseFactory.conflictResponse;
+import static net.smartcosmos.usermanagement.util.ResponseFactory.noContentResponse;
+import static net.smartcosmos.usermanagement.util.ResponseFactory.notFoundResponse;
+
+public class ResponseFactoryTest {
+
+    // region noContentResponse()
+
+    @Test
+    public void thatNoContentResponseReturnsResponseEntity() {
+
+        ResponseEntity<?> responseEntity = noContentResponse();
+
+        assertNotNull(responseEntity);
+    }
+
+    @Test
+    public void thatNoContentResponseReturns204NoContent() {
+
+        final HttpStatus expectedHttpStatus = HttpStatus.NO_CONTENT;
+
+        ResponseEntity<?> responseEntity = noContentResponse();
+
+        assertEquals(expectedHttpStatus, responseEntity.getStatusCode());
+    }
+
+    @Test
+    public void thatNoContentResponseReturnsNoBody() {
+
+        ResponseEntity<?> responseEntity = noContentResponse();
+
+        assertFalse(responseEntity.hasBody());
+    }
+
+    // endregion
+
+    // region notFoundResponse()
+
+    @Test
+    public void thatNotFoundResponseReturnsResponseEntity() {
+
+        ResponseEntity<?> responseEntity = notFoundResponse();
+
+        assertNotNull(responseEntity);
+    }
+
+    @Test
+    public void thatNotFoundResponseReturns404NotFound() {
+
+        final HttpStatus expectedHttpStatus = HttpStatus.NOT_FOUND;
+
+        ResponseEntity<?> responseEntity = notFoundResponse();
+
+        assertEquals(expectedHttpStatus, responseEntity.getStatusCode());
+    }
+
+    @Test
+    public void thatNotFoundResponseReturnsNoBody() {
+
+        ResponseEntity<?> responseEntity = notFoundResponse();
+
+        assertFalse(responseEntity.hasBody());
+    }
+
+    // endregion
+
+    // region conflictResponse()
+
+    @Test
+    public void thatConflictResponseReturnsResponseEntity() {
+
+        String message = "";
+        ResponseEntity<?> responseEntity = conflictResponse(message);
+
+        assertNotNull(responseEntity);
+    }
+
+    @Test
+    public void thatConflictResponseReturns409Conflict() {
+
+        final HttpStatus expectedHttpStatus = HttpStatus.CONFLICT;
+
+        String message = "";
+        ResponseEntity<?> responseEntity = conflictResponse(message);
+
+        assertEquals(expectedHttpStatus, responseEntity.getStatusCode());
+    }
+
+    @Test
+    public void thatConflictResponseReturnsNoBodyWhenMessageEmpty() {
+
+        String message = "";
+        ResponseEntity<?> responseEntity = conflictResponse(message);
+
+        assertFalse(responseEntity.hasBody());
+    }
+
+    @Test
+    public void thatConflictResponseReturnsNoBodyWhenMessageNull() {
+
+        String message = null;
+        ResponseEntity<?> responseEntity = conflictResponse(message);
+
+        assertFalse(responseEntity.hasBody());
+    }
+
+    @Test
+    public void thatConflictResponseReturnsBodyWhenMessageSet() {
+
+        String message = "someMessage";
+        ResponseEntity<?> responseEntity = conflictResponse(message);
+
+        assertTrue(responseEntity.hasBody());
+    }
+
+    @Test
+    public void thatConflictResponseBodyContainsMessageField() {
+
+        String expectedMessage = "someMessage";
+        ResponseEntity<?> responseEntity = conflictResponse(expectedMessage);
+
+        assertTrue(responseEntity.getBody() instanceof Map);
+        Map<String, Object> responseBody = (Map<String, Object>) responseEntity.getBody();
+
+        assertTrue(responseBody.containsKey(MESSAGE));
+        assertTrue(responseBody.get(MESSAGE) instanceof String);
+        assertEquals(expectedMessage, responseBody.get(MESSAGE));
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fixes two bugs in Update Role:
- the tenant URN was used as role URN
- **404 Not Found** was returned when the role name already existed

It also adds `ResponseFactory` utility class to move response creation out of the services. Note that not all services are updated to use this utility. It's intended as a starter, and currently is not commonly used in the project.

### How is this patch documented?

- Code
- Javadoc

### How was this patch tested?

Existing and additional unit tests, as well as newly added Postman tests.

#### Depends On

Nothing.