### PR TITLE
add create interactions authority

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 === New Features
 
+* OBJECTS-1133 Add authority to admin role to create Interactions
 * OBJECTS-980 Add Prometheus-compatible `/metrics` endpoint
 
 === Bugfixes & Improvements

--- a/src/main/java/net/smartcosmos/usermanagement/tenant/persistence/TenantDao.java
+++ b/src/main/java/net/smartcosmos/usermanagement/tenant/persistence/TenantDao.java
@@ -30,6 +30,7 @@ public interface TenantDao {
         "https://authorities.smartcosmos.net/relationships/create",
         "https://authorities.smartcosmos.net/relationships/read",
         "https://authorities.smartcosmos.net/relationships/delete",
+        "https://authorities.smartcosmos.net/interactions/create",
         "https://authorities.smartcosmos.net/tenants/read",
         "https://authorities.smartcosmos.net/tenants/update",
         "https://authorities.smartcosmos.net/users/create",


### PR DESCRIPTION
### What changes were proposed in this pull request?

* add authority https://authorities.smartcosmos.net/interactions/create

This change is required to enable Interactions in the Devkit.

### How is this patch documented?

* Authority from https://github.com/SMARTRACTECHNOLOGY/smartcosmos-ext-interactions/blob/master/README.adoc

#### Depends On

None.
